### PR TITLE
Add functionality to exclude directories from graph and update tsconf…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ data.json
 /package-lock.json
 /.tgitconfig
 /src/version_info.txt
+
+# exclude compiled .js in tests
+/tests/pathExclusion.js

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -58,6 +58,25 @@ export function createFolderIfNotExists(folderPath: string) {
 	 //  DebugMsg(DebugLevel.DEBUG,`Folder already exists: ${folderPath}`);
 	}
  }
+
+ // Allow for users to exclude directories within Vault from graph indexing
+export function isPathExcluded(path: string, excludedDirs: string[]): boolean {
+	return excludedDirs.some(dir => {
+	// Normalize paths to handle different path separators | Remove trailing slashes
+	const normalizedDir = dir.replace(/\\/g, '/').toLowerCase().replace(/\/+$/, ''); 
+	const normalizedPath = path.replace(/\\/g, '/').toLowerCase();
+	
+	// Handle wildcard matching (e.g., MyNotes/*)
+	if (normalizedDir.endsWith('/*')) {
+		// Remove /* to get the base directory
+		const baseDir = normalizedDir.slice(0, -2);
+		return normalizedPath === baseDir || normalizedPath.startsWith(baseDir + '/');
+	}
+
+	// Check for exact matches | exclude subdirectories of excluded directory
+	return normalizedPath === normalizedDir || normalizedPath.startsWith(normalizedDir + '/');
+	});
+};
 // 函数：获取所有标签
 export const getTags = (cache: CachedMetadata | null): TagCache[] => {
 	if (!cache || !cache.tags) return [];

--- a/tests/pathExclusion.ts
+++ b/tests/pathExclusion.ts
@@ -1,0 +1,36 @@
+export function isPathExcluded(path: string, excludedDirs: string[]): boolean {
+    return excludedDirs.some(dir => {
+        const normalizedDir = dir.replace(/\\/g, '/').toLowerCase().replace(/\/+$/, '');
+        const normalizedPath = path.replace(/\\/g, '/').toLowerCase();
+
+        // Handle wildcard matching (e.g., MyNotes/*)
+        if (normalizedDir.endsWith('/*')) {
+            const baseDir = normalizedDir.slice(0, -2);
+            return normalizedPath === baseDir || normalizedPath.startsWith(baseDir + '/');
+        }
+
+        // Check for exact matches or if the path is within the excluded directory
+        return normalizedPath === normalizedDir || normalizedPath.startsWith(normalizedDir + '/');
+    });
+}
+
+
+const testCases = [
+    { path: 'MyNotes/Section1/Notes', excludedDirs: ['MyNotes/*'], expected: true },
+    { path: 'Logs', excludedDirs: ['Logs'], expected: true },
+    { path: 'Logs/Archive', excludedDirs: ['Logs'], expected: true },
+    { path: 'NotesArchive', excludedDirs: ['Notes'], expected: false },
+    { path: 'Private/Notes', excludedDirs: ['Private'], expected: true },
+    { path: 'Projects/Important', excludedDirs: ['Projects/*'], expected: true },
+    { path: 'Projects', excludedDirs: ['Projects/*'], expected: true },
+    { path: 'Reports/2024', excludedDirs: ['Reports/*'], expected: true },
+    { path: 'Reports', excludedDirs: ['Archives'], expected: false }
+];
+
+testCases.forEach(({ path, excludedDirs, expected }, index) => {
+    const result = isPathExcluded(path, excludedDirs);
+    console.log(`Test ${index + 1}: Path "${path}" | ExcludedDirs: [${excludedDirs.join(', ')}] | Expected: ${expected} | Result: ${result}`);
+    console.assert(result === expected, `Test ${index + 1} failed`);
+});
+
+console.log('All tests completed.');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,18 +4,16 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",
-    "target": "ES6",
+    "target": "ES2015", // Ensures support for modern string methods
     "allowJs": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
-	"strictNullChecks": true,
+    "strictNullChecks": true,
     "lib": [
       "DOM",
-      "ES5",
-      "ES6",
-      "ES7"
+      "ES2015" // Includes ES6 and above features
     ]
   },
   "include": [


### PR DESCRIPTION
Very large, well tagged vault size causes the plugin to crash even on high powered hardware, Suggested changes allow users to exclude directories within vault from graph indexing, allowing for more controlled and useful graph content.